### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Normally, I'd agree with that, but it suits my workflow and might help you as we
 > Supported Node.js version: `6.x.x` and higher
 
 ### Yarn
-    $ yarn global add lana
+    $ yarn global add lana-cli
 
 ### NPM
-    $ npm i -g lana
+    $ npm i -g lana-cli
 
 ## Usage
 


### PR DESCRIPTION
replace module name `lana` with `lana-cli`


It seems that `lana` is another package

```zsh
➜  ~ yarn info lana bin
yarn info v0.19.1
{ 'install-lana': './bin/install-lana',
  'lana-add-project': './bin/lana-add-project',
  lanactl: './bin/lanactl' }
✨  Done in 0.48s.
➜  ~ yarn info lana-cli bin
yarn info v0.19.1
{ lana: 'cli.js' }
✨  Done in 0.53s.
➜  ~ 
```