### PR TITLE
Implement workaround for paprikka/lana-cli#5

### DIFF
--- a/__mocks__/child_process.js
+++ b/__mocks__/child_process.js
@@ -1,6 +1,6 @@
 module.exports = {
     addListener: jest.fn( (event, cb) => cb() ),
-    spawn: jest.fn((commands, args, opts)=> ({
+    spawn: jest.fn(() => ({
         stdin: jest.fn(),
         addListener: jest.fn()
     }))

--- a/integration/example_formatted/index.js
+++ b/integration/example_formatted/index.js
@@ -1,6 +1,7 @@
 const chalk = require('chalk')
 const clear = () => process.stdout.write('\x1Bc')
 clear()
+// eslint-disable-next-line no-console
 console.log(
 chalk.yellow(
 `

--- a/src/clear.js
+++ b/src/clear.js
@@ -1,6 +1,19 @@
 const proc = require('./utils/process')
 function clear () {
-    proc.stdout.write('\x1Bc')
+
+    // Workaround for Windows with Node version 6
+    // Based on: https://gist.github.com/KenanSulayman/4990953
+    // Fixes: https://github.com/paprikka/lana-cli/issues/5
+    const isWindows = process.platform === 'win32'
+    const isNode6 = Number(proc.version.slice(1, 2)) >= 6
+    const applyWorkaround = isWindows && isNode6
+
+    if (applyWorkaround) {
+        // clear terminal, reset cursor
+        proc.stdout.write('\x1B[2J\x1B[0f')
+    } else {
+        proc.stdout.write('\x1Bc')
+    }
 }
 
 module.exports = clear

--- a/src/get-docs.test.js
+++ b/src/get-docs.test.js
@@ -1,4 +1,4 @@
-
+const path = require('path')
 
 describe('get-docs', () => {
     let getDocs
@@ -20,7 +20,8 @@ describe('get-docs', () => {
         const root = '/foo/bar/baz'
         require('./get-docs')(root)
         expect(readFile).toBeCalled()
-        expect(readFile.mock.calls[0][0]).toEqual(root + '/README.md')
+        const readme = path.join(root, 'README.md')
+        expect(readFile.mock.calls[0][0]).toEqual(readme)
     })
 
     it('should reject with NO_DOCS_AVAILABLE error if README not found', () => {

--- a/src/render-state.js
+++ b/src/render-state.js
@@ -3,7 +3,6 @@ const clear = require('./clear')
 const chalk = require('chalk')
 
 
-const bullet = chalk.blue('•')
 const renderItem = ({ label, name }, isSelected) => {
     if (isSelected) return chalk.blue.bold(`• ${name}: ${label} `)
     return chalk.white(`  ${name}: `) + chalk.gray(label)


### PR DESCRIPTION
This PR improves `lana`'s Windows support and, thus, solves paprikka/lana-cli#5.

This PR also:
- fixes 3 linting issues
- fixes 1 test which failed on windows due to an incorrectly joined path.