### PR TITLE
Allow circling back on scripts with up/down arrow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,8 +81,6 @@ const getInitialState = (root, pkg) => {
 const initInput = state => {
     keypress(process.stdin)
 
-    const { min, max } = Math
-
     const handleKeyPress = (ch, key) => {
         const isEscape = (key && key.ctrl && key.name == 'c') || key.name == 'escape'
         if (isEscape) {
@@ -90,12 +88,14 @@ const initInput = state => {
         }
 
         if (key.name == 'up') {
-            state.selectedInd = max(0, state.selectedInd - 1)
+            const newInd = state.selectedInd - 1
+            state.selectedInd = newInd >= 0 ? newInd : state.scripts.length - 1
             renderState(state)
             return
         }
         if (key.name == 'down') {
-            state.selectedInd = min(state.scripts.length - 1, state.selectedInd + 1)
+            const newInd = state.selectedInd + 1
+            state.selectedInd = newInd <= state.scripts.length - 1 ? newInd : 0
             renderState(state)
             return
         }


### PR DESCRIPTION
This PR changes the behaviour when pressing `down` on the last script or `up` on the first script (nothing happens, only re-render). Now it will circle (cycle?) back to the first/last script. 

Couldn't find a good way to test it and didn't want to spend too much time on it if you're not interested in the feature.

Please le me know if you are and how would you test it! :) 

An alternative would be not to re-render in those cases, but that's probably an unnecessary overoptimization? Dunno 🦐 

Anyway greetings from Argentina 🦙🦙🦙🦙🦙🦙

![goddamn gorgeous Argentine llama](https://user-images.githubusercontent.com/7825875/103457972-59551480-4ce2-11eb-9c69-03d9c41454e1.png)

